### PR TITLE
fixed php version to 7.2.6

### DIFF
--- a/build_php_7.sh
+++ b/build_php_7.sh
@@ -5,7 +5,7 @@
 #
 # You can specify the PHP Version by setting the Git Branch from https://github.com/php/php-src
 
-PHP_VERSION_GIT_BRANCH=PHP-7.1.1
+PHP_VERSION_GIT_BRANCH=PHP-7.2.6
 
 echo "Build PHP Binary from current branch '$PHP_VERSION_GIT_BRANCH' on https://github.com/php/php-src"
 


### PR DESCRIPTION
When building 7.1.1 locally it fails (as does the travis build). This fixes it (it also happens to be the version I wanted!) Later versions may also be fine.